### PR TITLE
Add option to make CRediT role selection mandatory for each contributor

### DIFF
--- a/CreditPlugin.php
+++ b/CreditPlugin.php
@@ -27,7 +27,6 @@ use PKP\plugins\GenericPlugin;
 use PKP\plugins\Hook;
 use PKP\author\maps\Schema;
 use APP\author\Author;
-use PKP\oai\OAIRecord;
 
 use APP\plugins\generic\credit\classes\form\CreditSettingsForm;
 
@@ -51,15 +50,16 @@ class CreditPlugin extends GenericPlugin
                 });
 
                 Hook::add('Form::config::before', [$this, 'addCreditRoles']);
-                Hook::add('Schema::get::author', function ($hookName, $args) {
+                Hook::add('Schema::get::author', function ($hookName, $args) use ($contextId) {
                     $schema = $args[0];
+                    $requireCreditRoles = $this->getSetting($contextId, 'requireCreditRoles');
+                    $validation = $requireCreditRoles ? ['required'] : ['nullable'];
+                    
                     $schema->properties->creditRoles = json_decode('{
-                        "type": "array",
-                        "validation": [
-                                "nullable"
-                        ],
-                        "items": {
-                                "type": "string"
+			"type": "array",
+			"validation": ' . json_encode($validation) . ',
+			"items": {
+				"type": "string"
                         }
                     }');
 
@@ -67,7 +67,6 @@ class CreditPlugin extends GenericPlugin
                 if ($this->getSetting($contextId, 'showCreditRoles')) {
                     Hook::add('TemplateManager::display', [$this, 'handleTemplateDisplay']);
                 }
-                Hook::add('JatsTemplatePlugin::jats', $this->augmentJats(...));
             }
             return true;
         }
@@ -246,6 +245,7 @@ class CreditPlugin extends GenericPlugin
         }
 
         $author = $form->_author ?? null;
+        $requireCreditRoles = $this->getSetting($context->getId(), 'requireCreditRoles');
 
         $form->addField(new \PKP\components\forms\FieldOptions('creditRoles', [
             'type' => 'checkbox',
@@ -253,6 +253,7 @@ class CreditPlugin extends GenericPlugin
             'description' => __('plugins.generic.credit.contributorRoles.description'),
             'options' => $roleList,
             'value' => $author?->getData('creditRoles') ?? [],
+            'isRequired' => $requireCreditRoles,
         ]));
 
         return Hook::CONTINUE;
@@ -273,33 +274,6 @@ class CreditPlugin extends GenericPlugin
             return $json['translations'];
         }
         throw new \Exception('Unable to load JSON CRediT role list!');
-    }
-
-    /**
-     * Add the CRediT role information to the JATS contributor list
-     */
-    public function augmentJats($hookName, OAIRecord $record, \DOMDocument $doc) {
-        $submission = $record->getData('article');
-        $publication = $submission->getCurrentPublication();
-        $roleVocabulary = $this->getCreditRoles($submission->getData('locale'));
-        $xpath = new \DOMXPath($doc);
-	$authorsArray = array_values($publication->getData('authors')->toArray());
-        foreach ($xpath->query('//article/front/article-meta/contrib-group/contrib') as $matchIndex => $contribNode) {
-            $match = $xpath->query('//email', $contribNode);
-            if (!$match->length) continue;
-	    $author = $authorsArray[$matchIndex];
-            $creditRoles = $author->getData('creditRoles');
-            if (!$creditRoles) continue;
-
-            foreach ($creditRoles as $role) {
-                $roleNode = $contribNode->insertBefore($doc->createElement('role'), $contribNode->firstChild);
-                $roleNode->setAttribute('vocab-identifier', 'https://credit.niso.org/');
-                $roleNode->setAttribute('vocab-term', $roleVocabulary[$role]['name']);
-                $roleNode->setAttribute('vocab-term-identifier', $role);
-                $roleNode->nodeValue = $roleVocabulary[$role]['name'];
-            }
-        }
-        return Hook::CONTINUE;
     }
 }
 

--- a/CreditPlugin.php
+++ b/CreditPlugin.php
@@ -27,7 +27,7 @@ use PKP\plugins\GenericPlugin;
 use PKP\plugins\Hook;
 use PKP\author\maps\Schema;
 use APP\author\Author;
-
+use PKP\oai\OAIRecord;
 use APP\plugins\generic\credit\classes\form\CreditSettingsForm;
 
 class CreditPlugin extends GenericPlugin
@@ -274,6 +274,33 @@ class CreditPlugin extends GenericPlugin
             return $json['translations'];
         }
         throw new \Exception('Unable to load JSON CRediT role list!');
+    }
+    
+     /**
+     * Add the CRediT role information to the JATS contributor list
+     */
+    public function augmentJats($hookName, OAIRecord $record, \DOMDocument $doc) {
+        $submission = $record->getData('article');
+        $publication = $submission->getCurrentPublication();
+        $roleVocabulary = $this->getCreditRoles($submission->getData('locale'));
+        $xpath = new \DOMXPath($doc);
+	$authorsArray = array_values($publication->getData('authors')->toArray());
+        foreach ($xpath->query('//article/front/article-meta/contrib-group/contrib') as $matchIndex => $contribNode) {
+            $match = $xpath->query('//email', $contribNode);
+            if (!$match->length) continue;
+	    $author = $authorsArray[$matchIndex];
+            $creditRoles = $author->getData('creditRoles');
+            if (!$creditRoles) continue;
+
+            foreach ($creditRoles as $role) {
+                $roleNode = $contribNode->insertBefore($doc->createElement('role'), $contribNode->firstChild);
+                $roleNode->setAttribute('vocab-identifier', 'https://credit.niso.org/');
+                $roleNode->setAttribute('vocab-term', $roleVocabulary[$role]['name']);
+                $roleNode->setAttribute('vocab-term-identifier', $role);
+                $roleNode->nodeValue = $roleVocabulary[$role]['name'];
+            }
+        }
+        return Hook::CONTINUE;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,24 @@ Working group:
 - Esko Clarke Sario: Finnish Lifelong Learning Foundation (Kvs)
 - Alec Smecher: Public Knowledge Project
 - Frederique Belliard: Delft University of Technology - Library
+
+## Configuration
+
+The plugin provides the following settings:
+
+1. **Show CRediT roles by author names on article landing pages** - When enabled, CRediT roles will be displayed next to author names on article pages.
+
+2. **Require at least one CRediT role for each contributor** - When enabled, editors must select at least one CRediT role for each contributor. The contributor form will validate this requirement.
+
+## Usage
+
+After enabling the plugin:
+
+1. Go to Settings > Website > Plugins > Generic Plugins
+2. Find "CRediT Plugin" and click "Settings"
+3. Enable/disable the options as needed:
+   - Check "Show CRediT roles..." to display roles on article pages
+   - Check "Require at least one CRediT role..." to make role selection mandatory
+4. Save your settings
+
+When editing contributors in submissions, you will see the CRediT roles available for selection. If the "require" option is enabled, you must select at least one role before saving.

--- a/classes/form/CreditSettingsForm.php
+++ b/classes/form/CreditSettingsForm.php
@@ -3,8 +3,8 @@
 /**
  * @file classes/form/CreditSettingsForm.php
  *
- * Copyright (c) 2014-2022 Simon Fraser University
- * Copyright (c) 2003-2022 John Willinsky
+ * Copyright (c) 2014-2025 Simon Fraser University
+ * Copyright (c) 2003-2025 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class CreditSettingsForm
@@ -80,7 +80,7 @@ class CreditSettingsForm extends Form
     {
         $contextId = $this->_getContextId();
         $plugin = $this->_getPlugin();
-        foreach (['showCreditRoles'] as $fieldName) {
+        foreach (['showCreditRoles', 'requireCreditRoles'] as $fieldName) {
             $this->setData($fieldName, $plugin->getSetting($contextId, $fieldName));
         }
     }
@@ -90,7 +90,7 @@ class CreditSettingsForm extends Form
      */
     public function readInputData()
     {
-        $this->readUserVars(['showCreditRoles']);
+        $this->readUserVars(['showCreditRoles', 'requireCreditRoles']);
     }
 
     /**
@@ -101,7 +101,7 @@ class CreditSettingsForm extends Form
         $plugin = $this->_getPlugin();
         $contextId = $this->_getContextId();
         parent::execute(...$functionArgs);
-        foreach (['showCreditRoles'] as $fieldName) {
+        foreach (['showCreditRoles', 'requireCreditRoles'] as $fieldName) {
             $plugin->updateSetting($contextId, $fieldName, $this->getData($fieldName));
         }
     }

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -28,3 +28,9 @@ msgstr "The CRediT vocabulary can interact with OJS in various ways. Use this fo
 
 msgid "plugins.generic.credit.showCreditRoles"
 msgstr "Show CRediT roles by author names on article landing pages."
+
+msgid "plugins.generic.credit.requireCreditRoles"
+msgstr "Require at least one CRediT role for each contributor."
+
+msgid "plugins.generic.credit.validation.required"
+msgstr "At least one CRediT role is required for each contributor."

--- a/locale/vi/locale.po
+++ b/locale/vi/locale.po
@@ -1,0 +1,36 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-11-19T11:05:26+00:00\n"
+"PO-Revision-Date: 2019-11-19T11:05:26+00:00\n"
+"Language: vi\n"
+
+msgid "plugins.generic.credit.name"
+msgstr "Plugin CRediT"
+
+msgid "plugins.generic.credit.description"
+msgstr "Plugin này thêm hỗ trợ cho bộ từ vựng đóng góp NISO CRediT."
+
+msgid "plugins.generic.credit.contributorRoles"
+msgstr "Vai trò CRediT"
+
+msgid "plugins.generic.credit.contributorRoles.description"
+msgstr "Vui lòng chọn vai trò của người đóng góp theo <a href=\"https://credit.niso.org/\" target="_new">danh sách NISO CRediT</a>."
+
+msgid "plugins.generic.credit.settings.description"
+msgstr "Từ vựng CRediT có thể tương tác với OJS theo nhiều cách khác nhau. Sử dụng biểu mẫu này để chọn tích hợp nào sẽ được sử dụng."
+
+msgid "plugins.generic.credit.showCreditRoles"
+msgstr "Hiển thị vai trò CRediT bên cạnh tên tác giả trên trang bài viết."
+
+msgid "plugins.generic.credit.requireCreditRoles"
+msgstr "Yêu cầu ít nhất một vai trò CRediT cho mỗi người đóng góp."
+
+msgid "plugins.generic.credit.validation.required"
+msgstr "Yêu cầu ít nhất một vai trò CRediT cho mỗi người đóng góp."

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -1,8 +1,8 @@
 {**
  * templates/settingsForm.tpl
  *
- * Copyright (c) 2022 Simon Fraser University
- * Copyright (c) 2022 John Willinsky
+ * Copyright (c) 2025 Simon Fraser University
+ * Copyright (c) 2025 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * Datacite plugin settings
@@ -21,6 +21,7 @@
 		<p class="pkp_help">{translate key="plugins.generic.credit.settings.description"}</p>
 		{fbvFormSection list="true"}
 			{fbvElement type="checkbox" id="showCreditRoles" label="plugins.generic.credit.showCreditRoles" checked=$showCreditRoles|compare:true}
+			{fbvElement type="checkbox" id="requireCreditRoles" label="plugins.generic.credit.requireCreditRoles" checked=$requireCreditRoles|compare:true}
 		{/fbvFormSection}
 	{/fbvFormArea}
 	{fbvFormButtons submitText="common.save"}


### PR DESCRIPTION
When enabled this option, editors must select at least one CRediT role for each contributor. The contributor form will validate this requirement.